### PR TITLE
[PKG-4444] Rebuild 0.15.0 for aarch64 ❄️ 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,12 +14,9 @@ source:
     - patches/0002-np.float-deprecated-alias-use-builtin-float.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [s390x or py>311]
-  # Segfault detected on some platforms during testing. This is enough of a reason to skip this arch for now
-  # Unfortunately this segfault is not documented anywhere
-  skip: True  # [linux and aarch64]
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
econml 0.15.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4444]
- [Upstream repository](https://github.com/Microsoft/EconML)

### Explanation of changes:

- Building for aarch64 because it was skipped due to issues with the tests. See previous PR here: https://github.com/AnacondaRecipes/econml-feedstock/pull/2
  - I was unable to find evidence of the segfault issue that caused us to skip this build, and it doesn't appear to be present in the build in this PR either.


[PKG-4444]: https://anaconda.atlassian.net/browse/PKG-4444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ